### PR TITLE
Added Job detail page

### DIFF
--- a/AppService/Services/JobService.cs
+++ b/AppService/Services/JobService.cs
@@ -184,7 +184,7 @@ namespace AppService.Services
 
         public JobLimited GetLimitedById(int id) => _jobRepository.GetJobLimitedById(id);
 
-        public Job GetById(int id) => _jobRepository.Get(x=>x.IsActive && x.Id == id).FirstOrDefault();
+        public Job GetById(int id) => _jobRepository.Get(x=>x.IsActive && x.Id == id, x => x.JoelTest, x => x.Category, x => x.Company, x => x.HireType).FirstOrDefault();
 
         public IEnumerable<CategoryCountDto> GetJobCountByCategory() => _jobRepository.GetJobCountByCategory();
 

--- a/Web/Controllers/JobsController.cs
+++ b/Web/Controllers/JobsController.cs
@@ -112,10 +112,8 @@ namespace Web.Controllers
             var seoUrl = job.Title.SanitizeUrl().SeoUrl(job.Id);
             var url = Url.AbsoluteAction(seoUrl, "jobs");
 
-
             await _slackService.PostNewJob(job, url);
 
-            // TODO adding this in the next PR - Carlos Campos
             return RedirectToAction(nameof(Detail), new
             {
                 id = job.Title.SanitizeUrl().SeoUrl(job.Id),
@@ -124,7 +122,7 @@ namespace Web.Controllers
         }
 
         // GET: /jobs/4-jobtitle
-        public ActionResult Detail(string id)
+        public IActionResult Detail(string id)
         {
             if (string.IsNullOrWhiteSpace(id))
                 return RedirectToAction(nameof(Index));
@@ -148,6 +146,7 @@ namespace Web.Controllers
 
             if (!expectedUrl.Equals(id, StringComparison.OrdinalIgnoreCase))
                 return RedirectToActionPermanent(nameof(Detail), new { id = expectedUrl });
+
 
             ViewBag.RelatedJobs =
                        _jobService.GetCompanyRelatedJobs(jobId, job.Company.Name);

--- a/Web/Framework/Extensions/IdentityExtensions.cs
+++ b/Web/Framework/Extensions/IdentityExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Security.Claims;
+namespace Web.Framework.Extensions
+{
+    public static class IdentityExtensions
+    {
+        public static int GetUserIdFromClaims(this ClaimsPrincipal user)
+        {
+            if (!user.Identity.IsAuthenticated)
+                return 0;
+
+            ClaimsPrincipal currentUser = user;
+            return Convert.ToInt32(currentUser.FindFirst("Id")?.Value);
+        }
+    }
+}

--- a/Web/Views/Account/Login.cshtml
+++ b/Web/Views/Account/Login.cshtml
@@ -8,5 +8,5 @@
 }
 
 <div class="container">
-    @Html.Partial("_Partials/ExternalLoginProviders")
+    <partial name="_Partials/ExternalLoginProviders" />
 </div>

--- a/Web/Views/Account/Profile.cshtml
+++ b/Web/Views/Account/Profile.cshtml
@@ -34,8 +34,8 @@
                     </div>
                     @if (Model.Jobs != null && Model.Jobs.Any())
                     {
-                    <link href="/Content/toggleButton.css" rel="stylesheet" />
-                    @Html.Partial("../Jobs/_Partials/JobList", Model.Jobs.OrderByDescending(x => x.CreatedAt))
+                        <link href="/Content/toggleButton.css" rel="stylesheet" />
+                        <partial name="../Jobs/_Partials/JobList" model="Model.Jobs.OrderByDescending(x => x.CreatedAt)" />
                     }
                     else
                     {

--- a/Web/Views/Home/Index.cshtml
+++ b/Web/Views/Home/Index.cshtml
@@ -27,8 +27,7 @@
             });
 });</script>
 }
-
-@Html.Partial("../Jobs/_Partials/FindJobsPartial", (JobSearchViewModel)ViewBag.SearchViewModel)
+<partial name="../Jobs/_Partials/FindJobsPartial" model="(JobSearchViewModel)ViewBag.SearchViewModel" />
 
 <div class="container" style="margin-top: -50px;">
     <section id="jobs">
@@ -37,7 +36,7 @@
                 <div>
                     <h2>Empleos Recientes</h2>
                 </div>
-                @Html.Partial("../Jobs/_Partials/JobList", Model)
+                <partial name="../Jobs/_Partials/JobList", model="Model" />
                 <br />
                 <a class="btn btn-primary" asp-controller="Jobs" asp-action="Index">Mostrar mas empleos</a>
             </div>

--- a/Web/Views/Jobs/Detail.cshtml
+++ b/Web/Views/Jobs/Detail.cshtml
@@ -1,0 +1,181 @@
+﻿@using System.Text.RegularExpressions
+@using Web.Framework.Extensions
+@using Microsoft.AspNetCore.Identity
+
+@model Domain.Job
+
+@if (Model != null)
+{
+    ViewBag.Title = Model.Title;
+    ViewBag.Description = Regex.Replace(Model.Description, @"<(.|\n)*?>", "");
+    ViewBag.ImageUrl = Model.Company.LogoUrl;
+
+    @Html.AntiForgeryToken();
+    <section id="title">
+        <div class="container">
+            <div class="row">
+                <div class="col-sm-12 text-center">
+                    <h1>@Model.Title</h1>
+                    <div class="job-title">
+                        @if (Model == null)
+                        {
+                            <h5><i class="fa fa-map-marker"></i>N/A</h5>
+                        }
+                        else
+                        {
+                            <h5><i class="fa fa-map-marker"></i> @Model.Title</h5>
+                        }
+
+                        <h5><i class="fa fa-cog"></i> @Model.Category.Name</h5>
+
+                        @if (Model.IsRemote)
+                        {
+                            <h5><i class="fa fa-globe"></i> Remoto</h5>
+                        }
+                        <h5><i class="fa fa-info"></i> @Model.HireType.Name</h5>
+                    </div>
+                    <h5 class="text-center"><i class="fa fa-calendar"></i> @Model.CreatedAt.ToString("dd MMMM yyyy")</h5>
+                </div>
+            </div>
+        </div>
+    </section>
+    <section id = "jobs">
+
+         <div class="container">
+            <div class="row">
+                <div class="col-sm-8">
+                    <article>
+                        <h2>Detalles del Puesto</h2>
+                        <article>
+                            @Html.Raw(Model.Description)
+                        </article>
+                        <h3>Como aplicar</h3>
+                        @if (Model.HowToApply != null)
+                        {
+                            <article>
+                                @Html.Raw(Model.HowToApply)
+                            </article>
+                        }
+
+                        <p>
+                            Enviar CV a<a href="mailto:@Model.Company.Email"> @Model.Company.Email</a>, recuerda agregar tu cover letter.
+                        </p>
+
+                    </article>
+                    <article>
+                        @if (Model.JoelTest != null)
+                        {
+                            <partial name="_Partials/_JoelTestResults" model="Model.JoelTest" />
+                        }
+                    </article>
+                </div>
+                <div class="col-sm-4" id="sidebar">
+                    @if(Model.UserId == User.GetUserIdFromClaims())
+                    {
+                        var titleUrl = Model.Title.SanitizeUrl().SeoUrl(Model.Id);
+                        <div class="sidebar-widget">
+                            <h2>Administración</h2>
+                            <div>
+                                @if(Model.IsHidden)
+                                {
+                                    <button asp-action="ToggleHide" asp-controller="Jobs" asp-route-title="titleUrl"  
+                                            class="btn btn-admin btn-toggle-hide" id="switch-btn">
+                                        Mostrar
+                                    </button>
+                                }
+                                else
+                                {
+                                    <button asp-action="ToggleHide" asp-controller="Jobs" asp-route-title="titleUrl" 
+                                            class="btn btn-admin btn-toggle-show" id="switch-btn">
+                                        Ocultar
+                                    </button>
+                                }
+
+                                <a href="#"
+                                   class="btn btn-admin btn-primary">Editar</a>
+                                <a class="btn btn-admin btn-danger" href="#"
+                                   id="delete-btn" data-toggle="modal" data-target="#confirm-delete" data-title="@Model.Title">Borrar</a>
+                            </div>
+                        </div>
+                    }
+                    <div class="sidebar-widget" id="likes">
+                        <h2>Likes</h2>
+                        <div>
+                            @{
+                                var disabledClass = @Html.Raw(!ViewBag.CanLike ? "disabled" : "");
+                            }
+                            <input type = "hidden" id="like-url" value="@Url.Action("Like")" />
+                            <a href = "#" class="like-job like @disabledClass" title="Me gusta" data-job="@Model.Id" data-like="true" data-canlike="@ViewBag.CanLike.ToString().ToLower()">
+                                <i class="fa fa-lg fa-thumbs-o-up"></i>
+                                <span>@Model.Likes.FormatThousand()</span>
+                            </a>
+                        </div>
+                    </div>
+                    <div class="sidebar-widget text-center">
+                        <a href = "http://bit.ly/cdcempleado" >
+                            <img style="max-height:310px; max-width: 310px; height: auto; width: auto;" class="img-fluid" src="~/images/sponsors/cdc-banner.png" />
+                        </a>
+                    </div>
+                    <div class="sidebar-widget" id="share">
+                        <h2>Compartir</h2>
+                        <ul>
+                            <li><a target = "_blank" href="https://www.facebook.com/sharer/sharer.php?u=@Context.Request.Host@Context.Request.Path"><i class="fa fa-facebook"></i></a></li>
+                            <li><a target = "_blank" href="https://twitter.com/home?status=@Context.Request.Host@Context.Request.Path"><i class="fa fa-twitter"></i></a></li>
+                            <li><a target = "_blank" href="https://plus.google.com/share?url=@Context.Request.Host@Context.Request.Path"><i class="fa fa-google-plus"></i></a></li>
+                            <li><a target = "_blank" href="https://www.linkedin.com/shareArticle?mini=true&amp;url=@Context.Request.Host@Context.Request.Path&amp;summary=&amp;source="><i class="fa fa-linkedin"></i></a></li>
+                        </ul>
+                    </div>
+
+                    <hr>
+
+                    <div class="sidebar-widget" id="company">
+                        <h2>Sobre la Compañía</h2>
+
+                        <a href = "@Model.Company.Url" >
+                            @if(string.IsNullOrWhiteSpace(@Model.Company.LogoUrl))
+                            {
+                                <img src="~/images/company-logo-placeholder.png" alt="Logo Compañía" class="img-company img-responsive" />
+                            }
+                            else
+                            {
+                                <img src = "@Model.Company.LogoUrl" alt="Logo Compañía" class="img-company img-responsive">
+                            }
+                        </a>
+                        <h5>@Model.Company.Name</h5>
+                        <p>
+                            <a href = "@Model.Company.Name" class="btn btn-primary">Más sobre esta compañía</a>
+                          </p>
+                    </div>
+
+                    <hr>
+
+
+                      @if (((List<Job>) ViewBag.RelatedJobs).Any())
+                      {
+                        <div class="sidebar-widget" id="company-jobs">
+                            <h2>Más empleos de esta Compañía</h2>
+                            <ul>
+                                @foreach(var jobOpportunity in (List<Job>) ViewBag.RelatedJobs)
+                                {
+                                    <li><a asp-action="Detail" asp-controller="Jobs" asp-route-id="@jobOpportunity.Title.SanitizeUrl().SeoUrl(jobOpportunity.Id)"> @jobOpportunity.Title </a></li>
+                                }
+                            </ul>
+                        </div>
+                        <hr>
+                      }
+
+                    <div class="sidebar-widget" id="view-count">
+                        <h2>Visitas Realizadas</h2>
+                        <h3>@Model.ViewCount</h3>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+<partial name="_Partials/ConfirmDeleteModal" />
+}
+
+@section scripts
+{
+    <script src="/js/jobs/likes.js"></script>
+}

--- a/Web/Views/Jobs/Index.cshtml
+++ b/Web/Views/Jobs/Index.cshtml
@@ -26,7 +26,7 @@
         });
 });</script>
 }
-@Html.Partial("../Jobs/_Partials/FindJobsPartial", Model)
+<partial name="../Jobs/_Partials/FindJobsPartial", model="Model" />
 
 <div class="container">
     <div class="row">
@@ -45,7 +45,7 @@
                 </div>
 
                 <br />
-                @Html.Partial("../Jobs/_Partials/JobList", Model.Jobs)
+                <partial name="../Jobs/_Partials/JobList" model="Model.Jobs" />
                 <br />
 
                 @*Pagination*@

--- a/Web/Views/Jobs/_Partials/JobList.cshtml
+++ b/Web/Views/Jobs/_Partials/JobList.cshtml
@@ -7,7 +7,7 @@
         {
         var jobId = job.Title.SeoUrl(job.Id);
         <div class="featured">
-            <a asp-controller="Job" asp-action="Detail" asp-route-id="@jobId">
+            <a asp-controller="Jobs" asp-action="Detail" asp-route-id="@jobId">
                 <div class="row">
                     <div class="col-md-1 hidden-sm hidden-xs text-center">
                         @if (!string.IsNullOrEmpty(job.Company?.Url))
@@ -18,7 +18,7 @@
                              alt=""
                              class="img-responsive"
                              onclick="onJobOpportunityDetailClick(this);"
-                             data-url='<a asp-controller="Job", asp-action="Detail" asp-route-id="@jobId" />' />
+                             data-url='<a asp-controller="Jobs", asp-action="Detail" asp-route-id="@jobId" />' />
                         }
                         else
                         {
@@ -79,8 +79,8 @@
                 }
                 <label data-on="Mostrar" data-off="Ocultar"></label>
             </div>
-            <a style="@hideAdminOptions" asp-controller="Job" asp-action="Edit" asp-route-title="@jobId" class="admin-btn edit-btn">Editar</a>
-            <a style="@hideAdminOptions" asp-controller="Job" asp-action="Delete" asp-route-title="@jobId"
+            <a style="@hideAdminOptions" asp-controller="Jobs" asp-action="Edit" asp-route-title="@jobId" class="admin-btn edit-btn">Editar</a>
+            <a style="@hideAdminOptions" asp-controller="Jobs" asp-action="Delete" asp-route-title="@jobId"
                class="admin-btn delete-btn" data-toggle="modal" data-target="#confirm-delete" data-title="@job.Title">Borrar</a>
         </div>
         }

--- a/Web/Views/Jobs/_Partials/_JoelTestResults.cshtml
+++ b/Web/Views/Jobs/_Partials/_JoelTestResults.cshtml
@@ -1,0 +1,46 @@
+﻿@using Web.Framework.Extensions
+@model Domain.JoelTest
+
+<h4>La prueba de JOEL</h4>
+<p>
+    Es un cuestionario para medir la calidad del equipo de desarrollo de tu empresa. Coteja las opciones que apliquen.
+    <br />Esto es opcional y solo aplica para posiciones relacionadas al Desarrollo de Software
+</p>
+<div class="list-group">
+    <div class="list-group-item">
+        <b>¿Usan algún tipo de control de versiones? (Git, Subversion)</b> <span class="pull-right">@Html.Raw(Model.HasSourceControl.ToCheckTimesString())</span>
+    </div>
+    <div class="list-group-item">
+        <b>¿Pueden hacer pases a producción en un solo paso?</b> <span class="pull-right">@Html.Raw(Model.HasOneStepBuilds.ToCheckTimesString())</span>
+    </div>
+    <div class="list-group-item">
+        <b>¿Compilan el producto diariamente?</b> <span class="pull-right">@Html.Raw(Model.HasDailyBuilds.ToCheckTimesString())</span>
+    </div>
+    <div class="list-group-item">
+        <b>¿Tienen una base de datos de bugs?</b> <span class="pull-right">@Html.Raw(Model.HasBugDatabase.ToCheckTimesString())</span>
+    </div>
+    <div class="list-group-item">
+        <b>¿Corrigen los bugs antes de añadir más código?</b> <span class="pull-right">@Html.Raw(Model.HasBusFixedBeforeProceding.ToCheckTimesString())</span>
+    </div>
+    <div class="list-group-item">
+        <b>¿Tienen una planificación actualizada?</b> <span class="pull-right">@Html.Raw(Model.HasUpToDateSchedule.ToCheckTimesString())</span>
+    </div>
+    <div class="list-group-item">
+        <b>¿Tienes un documento de especificaciones?</b> <span class="pull-right">@Html.Raw(Model.HasSpec.ToCheckTimesString())</span>
+    </div>
+    <div class="list-group-item">
+        <b>¿Están los programadores en un lugar tranquilo?</b> <span class="pull-right">@Html.Raw(Model.HasQuiteEnvironment.ToCheckTimesString())</span>
+    </div>
+    <div class="list-group-item">
+        <b>¿Utilizan las mejores herramientas que puedes comprar?</b> <span class="pull-right">@Html.Raw(Model.HasBestTools.ToCheckTimesString())</span>
+    </div>
+    <div class="list-group-item">
+        <b>¿Tienen gente para probar los productos?</b> <span class="pull-right">@Html.Raw(Model.HasTesters.ToCheckTimesString())</span>
+    </div>
+    <div class="list-group-item">
+        <b>¿Hacen escribir código a los nuevos candidatos en las entrevistas?</b> <span class="pull-right">@Html.Raw(Model.HasWrittenTest.ToCheckTimesString())</span>
+    </div>
+    <div class="list-group-item">
+        <b>¿Hacen pruebas de usabilidad 'de vestíbulo'?</b> <span class="pull-right">@Html.Raw(Model.HasHallwayTests.ToCheckTimesString())</span>
+    </div>
+</div>


### PR DESCRIPTION
# What's new?
## Description
Job Detail page has been added. This allows the user to check in detail about a job opportunity available on the site.

If the user is not the owner of the Job, it will only able to see its information. If the user is the owner, a admin control will be shown to manage the status of the job post either: Hide the post, edit or delete the post.

Although the admin control is available, it can not be used yet until further implementations.

## Additional notes

- Job links on the home page has been fixed
- Alerts are not available on the site, this is making the web site going blank when a notification (alert) wants to be shown (maybe we can add this as priority feature/bug).
- If the user creates a Job, it will not be able to see it until it's approved (but since alerts are not available, the page will go blank if the job is not approved yet).

## Visual Aids

### Job Detail Page
<img width="720" alt="screen shot 2018-08-20 at 1 42 52 am" src="https://user-images.githubusercontent.com/8483978/44330000-26689980-a423-11e8-95ca-5a987b598815.png">

<img width="720" alt="screen shot 2018-08-20 at 1 43 01 am" src="https://user-images.githubusercontent.com/8483978/44330034-3da78700-a423-11e8-8218-4d70103a6705.png">

### Job Detail Page with Admin Controls
<img width="720" alt="screen shot 2018-08-20 at 2 47 48 am" src="https://user-images.githubusercontent.com/8483978/44330142-83644f80-a423-11e8-839b-2f538fe7abe1.png">