### PR TITLE
Fix: README - Invalid link order

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,10 +12,10 @@ After you setup your Ubuntu command line on Windows (user, password, etc.), you 
 # Getting the .NET SDK
 
 ## Windows
-Download the .Net SDK [in this link](https://www.microsoft.com/net/download/thank-you/dotnet-sdk-2.1.302-macos-x64-installer) or paste this in your  browser https://www.microsoft.com/net/download/thank-you/dotnet-sdk-2.1.302-macos-x64-installer
+Download the .Net SDK [in this link](https://www.microsoft.com/net/download/thank-you/dotnet-sdk-2.1.302-macos-x64-installer) or paste this in your  browser https://www.microsoft.com/net/download/thank-you/dotnet-sdk-2.1.302-windows-x64-installer
 
 ## Mac 
-Download the .Net SDK [in this link](https://www.microsoft.com/net/download/thank-you/dotnet-sdk-2.1.302-windows-x64-installer) or paste this in your  browser https://www.microsoft.com/net/download/thank-you/dotnet-sdk-2.1.302-windows-x64-installer
+Download the .Net SDK [in this link](https://www.microsoft.com/net/download/thank-you/dotnet-sdk-2.1.302-windows-x64-installer) or paste this in your  browser https://www.microsoft.com/net/download/thank-you/dotnet-sdk-2.1.302-macos-x64-installer 
 
 ## Linux
 Run the following commands to get the .NET SDK on the linux command line:


### PR DESCRIPTION
## What's New

- Fixed the links order for the the **Getting .NET SDK's** section of Windows and Mac.

> Before

![bad link order](https://user-images.githubusercontent.com/6517152/44367672-7173c280-a49e-11e8-8f78-9fc8b5aa3d1e.PNG)

> After

![well link order](https://user-images.githubusercontent.com/6517152/44367692-7f294800-a49e-11e8-97f8-7132ca706c4c.PNG)

