### PR TITLE
Added Show / Hide toogle button action

### DIFF
--- a/Api/Controllers/AuthController.cs
+++ b/Api/Controllers/AuthController.cs
@@ -22,7 +22,7 @@ namespace Api.Controllers
         }
 
         [HttpPost("v1.0/[controller]/token")]
-        public ActionResult<JwtSecurityToken> CreateToken([FromBody] CredentialModel model)
+        public IActionResult CreateToken([FromBody] CredentialModel model)
         {
             try
             {
@@ -39,13 +39,13 @@ namespace Api.Controllers
                     var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("THISISALONGTEST!!!"));
                     var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
-                    return new JwtSecurityToken(
+                    return new JsonResult(new JwtSecurityToken(
                         issuer: "https://emplea.do",
                         audience: "https://emplea.do",
                         claims: claims,
                         expires: DateTime.UtcNow.AddHours(24),
                         signingCredentials: creds
-                    );
+                    ));
                 }
             }
             catch(Exception ex)

--- a/Api/Controllers/JobsController.cs
+++ b/Api/Controllers/JobsController.cs
@@ -21,7 +21,7 @@ namespace Api.Controllers
         }
 
         [HttpGet]
-        public ActionResult<PagingResult<JobLimited>> Get(PaginationParameters parameters, JobsQueryParameter queryParameters)
+        public IActionResult Get(PaginationParameters parameters, JobsQueryParameter queryParameters)
         {
             try
             {
@@ -34,7 +34,7 @@ namespace Api.Controllers
                     Ascending = false
                 }, queryParameters);
 
-                return result;
+                return new JsonResult(result);
             }
             catch(Exception ex)
             {
@@ -46,7 +46,7 @@ namespace Api.Controllers
         }
 
         [HttpGet("{id}")]
-        public ActionResult<JobLimited> Get(int id)
+        public IActionResult Get(int id)
         {
             try
             {
@@ -54,7 +54,7 @@ namespace Api.Controllers
 
                 if(result == null)
                     return new NotFoundResult();
-                return result;
+                return new JsonResult(result);
             }
             catch
             {

--- a/AppService/Services/JobService.cs
+++ b/AppService/Services/JobService.cs
@@ -190,11 +190,12 @@ namespace AppService.Services
 
         public IEnumerable<Job> GetAllJobsPagedByFilters(JobPagingParameter parameter) => _jobRepository.GetAllJobsPagedByFilters(parameter);
 
-        public void ToggleHideState(Job jobOpportunity)
+        public Job ToggleHideState(Job jobOpportunity)
         {
             jobOpportunity.IsHidden = !jobOpportunity.IsHidden;
             _jobRepository.Update(jobOpportunity);
             _jobRepository.CommitChanges();
+            return jobOpportunity;
         }
 
         public void UpdateViewCount(int id)
@@ -217,6 +218,6 @@ namespace AppService.Services
         IEnumerable<CategoryCountDto> GetJobCountByCategory();
         IEnumerable<Job> GetLatestJobs(int quantity);
         IEnumerable<Job> GetAllJobsPagedByFilters(JobPagingParameter parameter);
-        void ToggleHideState(Job jobOpportunity);
+        Job ToggleHideState(Job jobOpportunity);
     }
 }

--- a/Web/Controllers/JobsController.cs
+++ b/Web/Controllers/JobsController.cs
@@ -168,9 +168,11 @@ namespace Web.Controllers
 
             if (IsJobOpportunityOwner(id) || ControllerContext.HttpContext.CookieExists(cookieView))
             {
-                return job.IsHidden
-                    ? View(nameof(Detail), job).WithInfo("Esta opportunidad de empleo está oculta, solo usted puede verla, para mostrarla en el listado, haga click en el boton \"Mostrar\" en el detalle de la oportunidad o en el su perfil de usuario")
-                    : View(nameof(Detail), job);
+                // TODO removed until message extension is fixed
+                //return job.IsHidden
+                //      ? View(nameof(Detail), job).WithInfo("Esta opportunidad de empleo está oculta, solo usted puede verla, para mostrarla en el listado, haga click en el boton \"Mostrar\" en el detalle de la oportunidad o en el su perfil de usuario")
+                //: View(nameof(Detail), job);
+                return View(nameof(Detail), job);
             }
 
             _jobService.UpdateViewCount(job.Id);
@@ -213,7 +215,7 @@ namespace Web.Controllers
             var job = GetJobOpportunityFromTitle(title);
             if (IsJobOpportunityOwner(title))
             {
-                _jobService.ToggleHideState(job);
+                job = _jobService.ToggleHideState(job);
             }
 
             return Json(new { isHidden = job.IsHidden });

--- a/Web/Views/Jobs/Detail.cshtml
+++ b/Web/Views/Jobs/Detail.cshtml
@@ -75,17 +75,17 @@
                         var titleUrl = Model.Title.SanitizeUrl().SeoUrl(Model.Id);
                         <div class="sidebar-widget">
                             <h2>Administración</h2>
-                            <div>
+                            <div id="hide-container">
                                 @if(Model.IsHidden)
                                 {
-                                    <button asp-action="ToggleHide" asp-controller="Jobs" asp-route-title="titleUrl"  
+                                    <button data-id="@titleUrl"  
                                             class="btn btn-admin btn-toggle-hide" id="switch-btn">
                                         Mostrar
                                     </button>
                                 }
                                 else
                                 {
-                                    <button asp-action="ToggleHide" asp-controller="Jobs" asp-route-title="titleUrl" 
+                                    <button data-id="@titleUrl" 
                                             class="btn btn-admin btn-toggle-show" id="switch-btn">
                                         Ocultar
                                     </button>
@@ -119,10 +119,10 @@
                     <div class="sidebar-widget" id="share">
                         <h2>Compartir</h2>
                         <ul>
-                            <li><a target = "_blank" href="https://www.facebook.com/sharer/sharer.php?u=@Context.Request.Host@Context.Request.Path"><i class="fa fa-facebook"></i></a></li>
-                            <li><a target = "_blank" href="https://twitter.com/home?status=@Context.Request.Host@Context.Request.Path"><i class="fa fa-twitter"></i></a></li>
-                            <li><a target = "_blank" href="https://plus.google.com/share?url=@Context.Request.Host@Context.Request.Path"><i class="fa fa-google-plus"></i></a></li>
-                            <li><a target = "_blank" href="https://www.linkedin.com/shareArticle?mini=true&amp;url=@Context.Request.Host@Context.Request.Path&amp;summary=&amp;source="><i class="fa fa-linkedin"></i></a></li>
+                            <li><a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=@Context.Request.Host@Context.Request.Path"><i class="fa fa-facebook"></i></a></li>
+                            <li><a target="_blank" href="https://twitter.com/home?status=@Context.Request.Host@Context.Request.Path"><i class="fa fa-twitter"></i></a></li>
+                            <li><a target="_blank" href="https://plus.google.com/share?url=@Context.Request.Host@Context.Request.Path"><i class="fa fa-google-plus"></i></a></li>
+                            <li><a target="_blank" href="https://www.linkedin.com/shareArticle?mini=true&amp;url=@Context.Request.Host@Context.Request.Path&amp;summary=&amp;source="><i class="fa fa-linkedin"></i></a></li>
                         </ul>
                     </div>
 
@@ -131,7 +131,7 @@
                     <div class="sidebar-widget" id="company">
                         <h2>Sobre la Compañía</h2>
 
-                        <a href = "@Model.Company.Url" >
+                        <a href="@Model.Company.Url">
                             @if(string.IsNullOrWhiteSpace(@Model.Company.LogoUrl))
                             {
                                 <img src="~/images/company-logo-placeholder.png" alt="Logo Compañía" class="img-company img-responsive" />
@@ -178,4 +178,20 @@
 @section scripts
 {
     <script src="/js/jobs/likes.js"></script>
+    <script>
+        $("#switch-btn").on("click", function() {
+            $.post("@Url.Action("ToggleHide", "Jobs", new { title = Model.Title.SanitizeUrl().SeoUrl(Model.Id) })", function(data) {
+                if(data.isHidden === true) {
+                    @{ var titleUrl = Model.Title.SanitizeUrl().SeoUrl(Model.Id); } 
+                    $('#switch-btn').removeClass('btn btn-admin btn-toggle-show')
+                    $('#switch-btn').addClass('btn btn-admin btn-toggle-hide');
+                    $('#switch-btn').text('Mostrar');
+                } else { 
+                    $('#switch-btn').removeClass('btn btn-admin btn-toggle-hide')
+                    $('#switch-btn').addClass('btn btn-admin btn-toggle-show');
+                    $('#switch-btn').text('Ocultar');
+                }
+            });
+        });
+    </script>
 }


### PR DESCRIPTION
## What's new?
We have added the Show / Hide toggle button in the job detail page. This will allow the user that has published the Job Opportunity to either show or hide the opportunity to possible employees. 

## Visual Aids
<img width="800" alt="screen shot 2018-09-17 at 12 54 25 am" src="https://user-images.githubusercontent.com/8483978/45609249-4edcb700-ba14-11e8-9086-368b81ee271e.png">
<img width="800" alt="screen shot 2018-09-17 at 12 54 33 am" src="https://user-images.githubusercontent.com/8483978/45609250-51d7a780-ba14-11e8-9cb6-35defc5f2033.png">


## Aditional Notes
* I have fixed some action results on the Api project to be according to the .NET Core Foundation standards (use IActionResults instead of ActionResult<T>). This also fixes some problems when you try to run the project on VS Code (note that not all the problems are fixed yet).
* I have remove some extensions call to Alert extension library in order to see this PR working. This should be re-added on my next PR.