### PR TITLE
Alert extensions fixed

### DIFF
--- a/Web/Controllers/AccountController.cs
+++ b/Web/Controllers/AccountController.cs
@@ -43,7 +43,7 @@ namespace Web.Controllers
 
         [AllowAnonymous]
         [HttpPost]
-        public ActionResult ExternalLogin(string provider, string returnUrl)
+        public IActionResult ExternalLogin(string provider, string returnUrl)
         {
             var redirectUrl = string.Empty;
             switch(provider)
@@ -65,7 +65,7 @@ namespace Web.Controllers
             return RedirectToAction("Login").WithError(provider);
         }
 
-        public async Task<ActionResult> FacebookCallback(string code, string state, string returnUrl)
+        public async Task<IActionResult> FacebookCallback(string code, string state, string returnUrl)
         {
             if (state == _socialKeys.LocalVerificationToken)
             {
@@ -83,7 +83,7 @@ namespace Web.Controllers
             return RedirectToAction("New", "Jobs");
         }
 
-        public async Task<ActionResult> LinkedinCallback(string code, string state, string returnUrl)
+        public async Task<IActionResult> LinkedinCallback(string code, string state, string returnUrl)
         {
             if (state == _socialKeys.LocalVerificationToken)
             {
@@ -102,7 +102,7 @@ namespace Web.Controllers
         }
 
 
-        public async Task<ActionResult> GoogleCallback(string code, string state, string returnUrl)
+        public async Task<IActionResult> GoogleCallback(string code, string state, string returnUrl)
         {
             if (state == _socialKeys.LocalVerificationToken)
             {
@@ -121,7 +121,7 @@ namespace Web.Controllers
         }
 
 
-        public async Task<ActionResult> MicrosoftCallback(string code, string state, string returnUrl)
+        public async Task<IActionResult> MicrosoftCallback(string code, string state, string returnUrl)
         {
             if (state == _socialKeys.LocalVerificationToken)
             {
@@ -140,7 +140,7 @@ namespace Web.Controllers
         }
 
 
-        public async Task<ActionResult> LogOff()
+        public async Task<IActionResult> LogOff()
         {
             await SignOut();
             return RedirectToAction("Index", "Home");

--- a/Web/Framework/Helpers/Alerts/AlertDecoratorResult.cs
+++ b/Web/Framework/Helpers/Alerts/AlertDecoratorResult.cs
@@ -1,29 +1,30 @@
-﻿using System.Web;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Web.Framework.Helpers.Alerts
 {
-    public class AlertDecoratorResult : ActionResult
+    public class AlertDecoratorResult : IActionResult
     {
-        public ActionResult InnerResult { get; set; }
+        public IActionResult InnerResult { get; set; }
         public string AlertClass { get; set; }
         public string Message { get; set; }
 
-        public AlertDecoratorResult(ActionResult innerResult, string alertClass, string message)
+        public AlertDecoratorResult(IActionResult innerResult, string alertClass, string message)
         {
             InnerResult = innerResult;
             AlertClass = alertClass;
             Message = message;
         }
 
-        public override void ExecuteResult(ActionContext context)
+        public async Task ExecuteResultAsync(ActionContext context)
         {
-            var factory = context.HttpContext.RequestServices.GetService(typeof(ITempDataDictionaryFactory)) as ITempDataDictionaryFactory;
-            var tempData = factory.GetTempData(context.HttpContext) as TempDataDictionary;
+            var factory = context.HttpContext.RequestServices.GetService<ITempDataDictionaryFactory>();
+            var tempData = factory.GetTempData(context.HttpContext);
             var alerts = tempData.GetAlerts();
             alerts.Add(new Alert(AlertClass, Message));
-            InnerResult.ExecuteResult(context);
+            await InnerResult.ExecuteResultAsync(context);
         }
     }
 }

--- a/Web/Framework/Helpers/Alerts/AlertExtensions.cs
+++ b/Web/Framework/Helpers/Alerts/AlertExtensions.cs
@@ -18,24 +18,29 @@ namespace Web.Framework.Helpers.Alerts
             return (List<Alert>)tempData[Alerts];
         }
 
-        public static ActionResult WithSuccess(this ActionResult result, string message)
+        public static IActionResult WithSuccess(this IActionResult result, string message)
         {
-            return new AlertDecoratorResult(result, "alert-success", message);
+            return Alert(result, "alert-success", message);
         }
 
-        public static ActionResult WithInfo(this ActionResult result, string message)
+        public static IActionResult WithInfo(this IActionResult result, string message)
         {
-            return new AlertDecoratorResult(result, "alert-info", message);
+            return Alert(result, "alert-info", message);
         }
 
-        public static ActionResult WithWarning(this ActionResult result, string message)
+        public static IActionResult WithWarning(this IActionResult result, string message)
         {
-            return new AlertDecoratorResult(result, "alert-warning", message);
+            return Alert(result, "alert-warning", message);
         }
 
-        public static ActionResult WithError(this ActionResult result, string message)
+        public static IActionResult WithError(this IActionResult result, string message)
         {
-            return new AlertDecoratorResult(result, "alert-danger", message);
+            return Alert(result, "alert-danger", message);
+        }
+
+        private static IActionResult Alert(IActionResult result, string type, string body)
+        {
+            return new AlertDecoratorResult(result, type, body);
         }
     }
 }


### PR DESCRIPTION
## What's new?
The previous implementation of Alerts was using a wrong implementation of ActionResult. In order to make it work, I re-work the extension using IActionResult interface and ExecuteResultAsync method to show the InnerResult with the alert attached to it. 

Now alerts are being saved in the temp data of the context that the Action want to show when the page is rendered.

## Visual Aids
![screen shot 2018-09-18 at 12 52 10 am](https://user-images.githubusercontent.com/8483978/45669401-3d131680-badd-11e8-9421-eb434ea085b2.png)

## Aditional notes
In order to user watch a Job opportunity, the Details Action now Allow Anonymous users (which has validation to render the correct page in any use case We currently have).
