### PR TITLE
Remove LibMan from compilation process

### DIFF
--- a/Web/Web.csproj
+++ b/Web/Web.csproj
@@ -27,7 +27,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Scrutor" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="1.0.113" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What's new? ##

- Fue eliminado el proceso de restaurar las librerías javascript utilizando LibMan, cada vez que se compila el proyecto

### Visual aids ###

![image](https://user-images.githubusercontent.com/13991439/64864209-9afd1000-d604-11e9-8209-bc1f426573d9.png)

Close #76